### PR TITLE
Translate user texts to Portuguese

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,1 +1,1 @@
-Please refer to Zep's [Privacy Policy](https://help.getzep.com/legal/privacy-policy).
+Consulte a [Política de Privacidade](https://help.getzep.com/legal/privacy-policy) do Zep.

--- a/README.md
+++ b/README.md
@@ -1,97 +1,97 @@
-# Dify Zep Plugin
+# Plugin Zep para Dify
 
-A plugin for Dify that adds memory management using Zep. This helps your AI assistant remember past conversations and user information.
+Um plugin para o Dify que adiciona gerenciamento de memória usando o Zep. Isso ajuda seu assistente de IA a lembrar conversas passadas e informações do usuário.
 
-[View on GitHub](https://github.com/obadakhalili/dify-zep-plugin)
+[Ver no GitHub](https://github.com/obadakhalili/dify-zep-plugin)
 
-## Setup
+## Instalação
 
-1. Install the plugin in your Dify workspace
-2. Create a Zep project and get an API key
-3. Add your Zep API key to authorize the plugin
+1. Instale o plugin no seu workspace do Dify
+2. Crie um projeto no Zep e obtenha uma chave de API
+3. Adicione sua chave de API do Zep para autorizar o plugin
 
    ![authorize-1](_assets/authorize-1.png)
    ![authorize-2](_assets/authorize-2.png)
 
-## Tools
+## Ferramentas
 
-### 1. Init Session
+### 1. Iniciar Sessão
 
-Creates a Zep user and session if they don't already exist. Must be used first before other tools.
+Cria um usuário e sessão no Zep caso ainda não existam. Deve ser usada primeiro antes das outras ferramentas.
 
-**Parameters:**
+**Parâmetros:**
 
-- User ID - Unique identifier for the user
-- Session ID - Unique identifier for the conversation
+- ID do usuário - Identificador único do usuário
+- ID da sessão - Identificador único da conversa
 
-Returns the created or existing session details.
+Retorna os detalhes da sessão criada ou existente.
 
   ![init-session](_assets/init-session.png)
 
-### 2. Add Message to Session
+### 2. Adicionar Mensagem à Sessão
 
-Saves a message to the conversation memory.
+Salva uma mensagem na memória da conversa.
 
-**Parameters:**
+**Parâmetros:**
 
-- Session ID - The conversation to add to
-- Message - The text content to save
-- Role Type - Who sent the message (user or assistant)
-- Return Context (optional) - If true, also return relevant memory context
-- Ignore Roles (optional) - Roles to ignore when adding the message to graph memory
+- ID da sessão - A conversa que será atualizada
+- Mensagem - O texto a ser salvo
+- Tipo de papel - Quem enviou a mensagem (usuário ou assistente)
+- Retornar contexto (opcional) - Se verdadeiro, retorna também o contexto de memória relevante
+- Ignorar papéis (opcional) - Papéis a serem ignorados ao adicionar a mensagem à memória do grafo
 
   ![add-message.png](_assets/add-message.png)
 
-### 3. Get Session Memory
+### 3. Obter Memória da Sessão
 
-Gets user memory relevant to the last messages in the conversation.
+Obtém a memória do usuário relevante para as últimas mensagens da conversa.
 
-**Parameters:**
+**Parâmetros:**
 
-- Session ID - The conversation to get relevant memory for
-- Last N Messages (optional) - Number of recent messages to check (max 50)
-- Minimum Rating (optional) - Only return memories above this relevance score
+- ID da sessão - A conversa da qual obter a memória
+- Últimas N mensagens (opcional) - Quantidade de mensagens recentes a considerar (máx. 50)
+- Pontuação mínima (opcional) - Somente retornar memórias acima dessa relevância
 
   ![get-memory](_assets/get-memory.png)
 
-### 4. Search User Graph
+### 4. Buscar no Gráfico do Usuário
 
-Search through a user's memory for relevant information.
+Busca na memória do usuário por informações relevantes.
 
-**Parameters:**
+**Parâmetros:**
 
-- User ID - The user to search memories for
-- Query - What to search for in the memory
+- ID do usuário - O usuário para buscar memórias
+- Consulta - O que buscar na memória
 
   ![search-graph](_assets/search-graph.png)
 
-**Difference between `Get Session Memory` and `Search User Graph` tools:**
+**Diferença entre as ferramentas `Obter Memória da Sessão` e `Buscar no Gráfico do Usuário`:**
 
-- `Get Session Memory` uses the last n messages in the conversation to compose a query and search the user's memory for relevant information.
-- `Search User Graph` searches the user's memory for a query you provide.
+- `Obter Memória da Sessão` usa as últimas mensagens da conversa para compor uma consulta e buscar na memória do usuário informações relevantes.
+- `Buscar no Gráfico do Usuário` pesquisa na memória do usuário usando uma consulta fornecida por você.
 
-### 5. Delete Session
+### 5. Excluir Sessão
 
-Removes a session and all of its stored memory.
+Remove uma sessão e toda a sua memória armazenada.
 
-**Parameters:**
+**Parâmetros:**
 
-- Session ID - The session to remove
+- ID da sessão - A sessão a ser removida
 
-### 6. Get Session
+### 6. Obter Sessão
 
-Retrieves details about a session.
+Recupera detalhes de uma sessão.
 
-**Parameters:**
+**Parâmetros:**
 
-- Session ID - The session to fetch
+- ID da sessão - A sessão a ser buscada
 
-## Example workflow
+## Exemplo de fluxo
 
 ![workflow](_assets/workflow.png)
 
-## To-Dos:
+## Tarefas pendentes:
 
-- [ ] What if the user want to use the plugin with different API keys from more than one project?
-- [ ] How to use outside workflow apps?
-- [ ] Use `return_context` in `memory.get()` to use context immediatley.
+- [ ] E se o usuário quiser usar o plugin com chaves de API diferentes de mais de um projeto?
+- [ ] Como usar em aplicativos fora de fluxo de trabalho?
+- [ ] Usar `return_context` em `memory.get()` para utilizar o contexto imediatamente.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -4,8 +4,10 @@ author: obadakhalili
 name: zep
 label:
   en_US: Zep
+  pt_BR: Zep
 description:
   en_US: Dify memory management plugin using Zep
+  pt_BR: Plugin de gerenciamento de memória do Dify usando Zep
 icon: zep.png
 resource:
   memory: 268435456

--- a/provider/zep.yaml
+++ b/provider/zep.yaml
@@ -3,8 +3,10 @@ identity:
   name: zep
   label:
     en_US: Zep
+    pt_BR: Zep
   description:
     en_US: Dify Zep plugin
+    pt_BR: Plugin Dify para o Zep
   icon: zep.png
   tags:
     - utilities
@@ -15,10 +17,13 @@ credentials_for_provider:
     required: true
     label:
       en_US: Zep API key
+      pt_BR: Chave de API do Zep
     placeholder:
       en_US: Enter your Zep API key
+      pt_BR: Insira sua chave de API do Zep
     help:
       en_US: Get the API key from your Zep project
+      pt_BR: Obtenha a chave de API do seu projeto Zep
     url: https://app.getzep.com/projects
 
 tools:

--- a/tools/add_session_memory.yaml
+++ b/tools/add_session_memory.yaml
@@ -3,10 +3,12 @@ identity:
   author: obadakhalili
   label:
     en_US: Add message to session
+    pt_BR: Adicionar mensagem à sessão
 
 description:
   human:
     en_US: Add a new message to the session memory
+    pt_BR: Adicione uma nova mensagem à memória da sessão
   llm: Add a new message to the session memory
 
 parameters:
@@ -15,8 +17,10 @@ parameters:
     required: true
     label:
       en_US: Session ID
+      pt_BR: ID da sessão
     human_description:
       en_US: The session ID to add the message to
+      pt_BR: O ID da sessão para adicionar a mensagem
     llm_description: The session ID to add the message to
     form: llm
   - name: message
@@ -24,8 +28,10 @@ parameters:
     required: true
     label:
       en_US: Message Content
+      pt_BR: Conteúdo da mensagem
     human_description:
       en_US: The content of the message to store
+      pt_BR: O conteúdo da mensagem a ser armazenado
     llm_description: The content of the message to store
     form: llm
   - name: role_type
@@ -35,13 +41,17 @@ parameters:
       - value: user
         label:
           en_US: User
+          pt_BR: Usuário
       - value: assistant
         label:
           en_US: Assistant
+          pt_BR: Assistente
     label:
       en_US: Role Type
+      pt_BR: Tipo de papel
     human_description:
       en_US: The role of the message sender (user/assistant)
+      pt_BR: O papel de quem enviou a mensagem (usuário/assistente)
     llm_description: The role of the message sender (user/assistant)
     form: llm
   - name: return_context
@@ -49,8 +59,10 @@ parameters:
     required: false
     label:
       en_US: Return Context
+      pt_BR: Retornar contexto
     human_description:
       en_US: Whether to return relevant memory context after adding the message
+      pt_BR: Se deve retornar o contexto da memória após adicionar a mensagem
     llm_description: Whether to return relevant memory context after adding the message
     form: llm
   - name: ignore_roles
@@ -60,25 +72,33 @@ parameters:
       - value: user
         label:
           en_US: User
+          pt_BR: Usuário
       - value: assistant
         label:
           en_US: Assistant
+          pt_BR: Assistente
       - value: system
         label:
           en_US: System
+          pt_BR: Sistema
       - value: norole
         label:
           en_US: No Role
+          pt_BR: Sem papel
       - value: tool
         label:
           en_US: Tool
+          pt_BR: Ferramenta
       - value: function
         label:
           en_US: Function
+          pt_BR: Função
     label:
       en_US: Ignore Roles
+      pt_BR: Ignorar papéis
     human_description:
       en_US: Roles to ignore when adding the message to the graph
+      pt_BR: Papéis a serem ignorados ao adicionar a mensagem ao gráfico
     llm_description: Roles to ignore when adding the message to the graph
     form: llm
 

--- a/tools/delete_session.yaml
+++ b/tools/delete_session.yaml
@@ -3,10 +3,12 @@ identity:
   author: obadakhalili
   label:
     en_US: Delete session
+    pt_BR: Excluir sessão
 
 description:
   human:
     en_US: Delete a session and its memory from Zep
+    pt_BR: Excluir uma sessão e sua memória do Zep
   llm: Delete a session and its memory from Zep
 
 parameters:
@@ -15,8 +17,10 @@ parameters:
     required: true
     label:
       en_US: Session ID
+      pt_BR: ID da sessão
     human_description:
       en_US: The ID of the session to delete
+      pt_BR: O ID da sessão a ser excluída
     llm_description: The ID of the session to delete
     form: llm
 

--- a/tools/get_session.yaml
+++ b/tools/get_session.yaml
@@ -3,10 +3,12 @@ identity:
   author: obadakhalili
   label:
     en_US: Get session
+    pt_BR: Obter sessão
 
 description:
   human:
     en_US: Retrieve details about a session
+    pt_BR: Recuperar detalhes de uma sessão
   llm: Retrieve details about a session
 
 parameters:
@@ -15,8 +17,10 @@ parameters:
     required: true
     label:
       en_US: Session ID
+      pt_BR: ID da sessão
     human_description:
       en_US: The ID of the session to retrieve
+      pt_BR: O ID da sessão a ser recuperada
     llm_description: The ID of the session to retrieve
     form: llm
 

--- a/tools/get_session_memory.py
+++ b/tools/get_session_memory.py
@@ -38,4 +38,4 @@ class GetSessionMemoryTool(Tool):
         except Exception as e:
             err = str(e)
             yield self.create_json_message({"status": "error", "error": err})
-            yield self.create_text_message(f"failed to retrieve memory: {err}")
+            yield self.create_text_message(f"falha ao recuperar memória: {err}")

--- a/tools/get_session_memory.yaml
+++ b/tools/get_session_memory.yaml
@@ -3,10 +3,12 @@ identity:
   author: obadakhalili
   label:
     en_US: Get session memory
+    pt_BR: Obter memória da sessão
 
 description:
   human:
     en_US: Retrieves relevant memory context from the session based on recent messages
+    pt_BR: Recupera contexto de memória relevante da sessão com base nas mensagens recentes
   llm: Retrieves relevant memory context from the session based on recent messages
 
 parameters:
@@ -15,8 +17,10 @@ parameters:
     required: true
     label:
       en_US: Session ID
+      pt_BR: ID da sessão
     human_description:
       en_US: The session ID to retrieve memory from
+      pt_BR: O ID da sessão da qual obter a memória
     llm_description: The session ID to retrieve memory from
     form: llm
   - name: lastn
@@ -26,8 +30,10 @@ parameters:
     max: 50
     label:
       en_US: Last N messages
+      pt_BR: Últimas N mensagens
     human_description:
       en_US: The number of last messages to use for context retrieval
+      pt_BR: Quantidade de mensagens recentes para usar na recuperação de contexto
     llm_description: The number of last messages to use for context retrieval
     form: llm
   - name: min_rating
@@ -35,8 +41,10 @@ parameters:
     required: false
     label:
       en_US: Minimum rating
+      pt_BR: Pontuação mínima
     human_description:
       en_US: The minimum rating threshold for memory retrieval
+      pt_BR: A pontuação mínima para considerar na recuperação de memória
     llm_description: The minimum rating threshold for memory retrieval
     form: llm
 

--- a/tools/init_session.yaml
+++ b/tools/init_session.yaml
@@ -3,10 +3,12 @@ identity:
   author: obadakhalili
   label:
     en_US: Initialize session
+    pt_BR: Iniciar sessão
 
 description:
   human:
     en_US: Creates a new Zep session or ensures one exists for the conversation
+    pt_BR: Cria uma nova sessão Zep ou garante que uma exista para a conversa
   llm: Creates a new Zep session or ensures one exists for the conversation
 
 parameters:
@@ -15,8 +17,10 @@ parameters:
     required: true
     label:
       en_US: User ID
+      pt_BR: ID do usuário
     human_description:
       en_US: The user ID to initialize a session for
+      pt_BR: O ID do usuário para inicializar uma sessão
     llm_description: The user ID to initialize a session for
     form: llm
   - name: session_id
@@ -24,8 +28,10 @@ parameters:
     required: true
     label:
       en_US: Session ID
+      pt_BR: ID da sessão
     human_description:
       en_US: The ID of the session to initialize
+      pt_BR: O ID da sessão a ser iniciada
     llm_description: The ID of the session to initialize
     form: llm
 

--- a/tools/search_user_graph.py
+++ b/tools/search_user_graph.py
@@ -40,8 +40,8 @@ class SearchUserGraphTool(Tool):
             facts_str = ""
             if len(facts_list):
                 facts_str = f"""
-# These are the most relevant facts and their valid date ranges
-# format: FACT (Date range: from - to)
+# Estes são os fatos mais relevantes e seus intervalos de validade
+# formato: FATO (Data: de - até)
 <FACTS>
 {"\n".join(facts_list)}
 </FACTS>""".strip()
@@ -52,8 +52,8 @@ class SearchUserGraphTool(Tool):
             entities_str = ""
             if len(entities_list):
                 entities_str = f"""
-# These are the most relevant entities
-# ENTITY_NAME: entity summary
+# Estas são as entidades mais relevantes
+# NOME_DA_ENTIDADE: resumo da entidade
 <ENTITIES>
 {"\n".join(entities_list)}
 </ENTITIES>""".strip()
@@ -61,7 +61,7 @@ class SearchUserGraphTool(Tool):
             context_str = ""
             if facts_str or entities_str:
                 context_str = f"""
-FACTS and ENTITIES represent relevant context to the current conversation.
+FACTOS e ENTIDADES representam contexto relevante para a conversa atual.
 
 {facts_str}
 {entities_str}
@@ -74,4 +74,4 @@ FACTS and ENTITIES represent relevant context to the current conversation.
         except Exception as e:
             err = str(e)
             yield self.create_json_message({"status": "error", "error": err})
-            yield self.create_text_message(f"failed to retrieve memory: {err}")
+            yield self.create_text_message(f"falha ao recuperar memória: {err}")

--- a/tools/search_user_graph.yaml
+++ b/tools/search_user_graph.yaml
@@ -3,10 +3,12 @@ identity:
   author: obadakhalili
   label:
     en_US: Search user graph
+    pt_BR: Buscar gráfico do usuário
 
 description:
   human:
     en_US: Search user graph for relevant memory using a custom query
+    pt_BR: Buscar no gráfico do usuário por memória relevante usando uma consulta personalizada
   llm: Search user graph for relevant memory using a custom query
 
 parameters:
@@ -15,8 +17,10 @@ parameters:
     required: true
     label:
       en_US: User ID
+      pt_BR: ID do usuário
     human_description:
       en_US: The user ID to search the graph for
+      pt_BR: O ID do usuário para buscar no gráfico
     llm_description: The user ID to search the graph for
     form: llm
   - name: query
@@ -24,8 +28,10 @@ parameters:
     required: true
     label:
       en_US: Query
+      pt_BR: Consulta
     human_description:
       en_US: The query to use to search the graph
+      pt_BR: A consulta para usar na busca no gráfico
     llm_description: The query to use to search the graph
     form: llm
 


### PR DESCRIPTION
## Summary
- add Portuguese translations to provider manifest and tools
- localize README and privacy notice
- return Portuguese messages from memory tools

## Testing
- `python -m pip install -r requirements.txt`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68674342f130832f9bea6d38a76ec91d