### PR TITLE
Allow configuring Zep API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Um plugin para o Dify que adiciona gerenciamento de memória usando o Zep. Isso 
 1. Instale o plugin no seu workspace do Dify
 2. Crie um projeto no Zep e obtenha uma chave de API
 3. Adicione sua chave de API do Zep para autorizar o plugin
+4. (Opcional) Use o campo `zep_api_url` para definir uma URL base customizada da API se estiver usando uma instância do Zep diferente
 
    ![authorize-1](_assets/authorize-1.png)
    ![authorize-2](_assets/authorize-2.png)

--- a/provider/zep.py
+++ b/provider/zep.py
@@ -11,9 +11,11 @@ class ZepProvider(ToolProvider):
         api_key = credentials.get("zep_api_key")
         if not api_key:
             raise ToolProviderCredentialValidationError("Missing 'zep_api_key'")
+        api_url = credentials.get("zep_api_url")
+        base_url = f"{api_url}/api/v2" if api_url else None
 
         try:
-            client = Zep(api_key=api_key)
+            client = Zep(api_key=api_key, base_url=base_url)
             # Make a lightweight request to verify the API key without assuming
             # any specific sessions exist.
             client.memory.list_sessions(page_size=1)

--- a/provider/zep.yaml
+++ b/provider/zep.yaml
@@ -25,6 +25,18 @@ credentials_for_provider:
       en_US: Get the API key from your Zep project
       pt_BR: Obtenha a chave de API do seu projeto Zep
     url: https://app.getzep.com/projects
+  zep_api_url:
+    type: text-input
+    required: false
+    label:
+      en_US: Zep API base URL
+      pt_BR: URL base da API do Zep
+    placeholder:
+      en_US: https://api.getzep.com
+      pt_BR: https://api.getzep.com
+    help:
+      en_US: Override the Zep API base URL if needed
+      pt_BR: Substitua a URL base da API do Zep se necessário
 
 tools:
   - tools/init_session.yaml

--- a/tools/add_session_memory.py
+++ b/tools/add_session_memory.py
@@ -13,7 +13,9 @@ class AddSessionMemoryTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         try:
             api_key = self.runtime.credentials["zep_api_key"]
-            client = Zep(api_key=api_key)
+            api_url = self.runtime.credentials.get("zep_api_url")
+            base_url = f"{api_url}/api/v2" if api_url else None
+            client = Zep(api_key=api_key, base_url=base_url)
 
             return_context = tool_parameters.get("return_context")
             if isinstance(return_context, str):

--- a/tools/delete_session.py
+++ b/tools/delete_session.py
@@ -11,7 +11,9 @@ class DeleteSessionTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         try:
             api_key = self.runtime.credentials["zep_api_key"]
-            client = Zep(api_key=api_key)
+            api_url = self.runtime.credentials.get("zep_api_url")
+            base_url = f"{api_url}/api/v2" if api_url else None
+            client = Zep(api_key=api_key, base_url=base_url)
 
             client.memory.delete(session_id=tool_parameters["session_id"])
 

--- a/tools/get_session.py
+++ b/tools/get_session.py
@@ -12,7 +12,9 @@ class GetSessionTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         try:
             api_key = self.runtime.credentials["zep_api_key"]
-            client = Zep(api_key=api_key)
+            api_url = self.runtime.credentials.get("zep_api_url")
+            base_url = f"{api_url}/api/v2" if api_url else None
+            client = Zep(api_key=api_key, base_url=base_url)
 
             session = client.memory.get_session(session_id=tool_parameters["session_id"])
             yield self.create_json_message(

--- a/tools/get_session_memory.py
+++ b/tools/get_session_memory.py
@@ -12,7 +12,9 @@ class GetSessionMemoryTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         try:
             api_key = self.runtime.credentials["zep_api_key"]
-            client = Zep(api_key=api_key)
+            api_url = self.runtime.credentials.get("zep_api_url")
+            base_url = f"{api_url}/api/v2" if api_url else None
+            client = Zep(api_key=api_key, base_url=base_url)
 
             lastn = tool_parameters.get("lastn")
             if isinstance(lastn, str) and lastn.isdigit():

--- a/tools/init_session.py
+++ b/tools/init_session.py
@@ -13,7 +13,9 @@ class InitSessionTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         try:
             api_key = self.runtime.credentials["zep_api_key"]
-            client = Zep(api_key=api_key)
+            api_url = self.runtime.credentials.get("zep_api_url")
+            base_url = f"{api_url}/api/v2" if api_url else None
+            client = Zep(api_key=api_key, base_url=base_url)
 
             try:
                 session = client.memory.add_session(

--- a/tools/search_user_graph.py
+++ b/tools/search_user_graph.py
@@ -13,7 +13,10 @@ class SearchUserGraphTool(Tool):
         try:
             api_key = self.runtime.credentials["zep_api_key"]
 
-            client = Zep(api_key=api_key)
+            api_url = self.runtime.credentials.get("zep_api_url")
+            base_url = f"{api_url}/api/v2" if api_url else None
+
+            client = Zep(api_key=api_key, base_url=base_url)
 
             graph_edges = client.graph.search(
                 user_id=tool_parameters["user_id"],


### PR DESCRIPTION
## Summary
- support custom Zep API URL via optional `zep_api_url` credential
- pass new base URL to Zep client in provider and tools
- mention the new setting in the README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686745444b30832fa1b596a755fdec59